### PR TITLE
Add new scalar type GitObjectID.

### DIFF
--- a/src/ppx_graphql.ml
+++ b/src/ppx_graphql.ml
@@ -101,6 +101,7 @@ let convert_scalar : string -> Parsetree.expression =
   | "Int" -> [%expr to_int_option]
   | "Boolean" -> [%expr to_bool_option]
   | "URI"
+  | "GitObjectID"
   | "String" -> [%expr to_string_option]
   | "Float" -> [%expr to_float_option]
   | "ID" -> [%expr function


### PR DESCRIPTION
This is just a string, but is used by GitHub's GraphQL API.